### PR TITLE
Make "Slack - Quick Access" work with all workspaces, fixes #3

### DIFF
--- a/Slack/redirect.js
+++ b/Slack/redirect.js
@@ -13,6 +13,6 @@ browser.webRequest.onBeforeSendHeaders.addListener(
     });
     return { requestHeaders: e.requestHeaders };
   },
-  { urls: ["https://app.slack.com/*"] },
+  { urls: ["https://*.slack.com/*"] },
   ["blocking", "requestHeaders"]
 );


### PR DESCRIPTION
The `Slack - Quick Access` add on needs to override the user agent string when making requests in order to bypass Slack's latest version restrictions. This was achieved in [f4f8bc1](https://github.com/tdmrhn/Thunderbird-Quick-Access-Buttons/commit/f4f8bc1795c9b840879c50a84b987abf7bcee38c) but some users (including myself) were still experiencing problems.

Trying to debug it, I noticed that the `Slack - Quick Access` add-on was overriding the user agent in some requests but not in all. I noticed that my workspace URL was in the form `<workspace>.slack.com`, and thus was not covered by the rule in https://github.com/tdmrhn/Thunderbird-Quick-Access-Buttons/blob/bfc69ebf9027375140d9abc6867d697611e83cf3/Slack/redirect.js#L16

Changing that line to `{ urls: ["https://*.slack.com/*"] },` has made it work for me (on Thunderbird 115.10.1)