### PR TITLE
Update Telegram redirect.js title

### DIFF
--- a/Telegram/redirect.js
+++ b/Telegram/redirect.js
@@ -1,5 +1,5 @@
 browser.spacesToolbar.addButton('Telegram', {
-    title: "Telegram Keep",
+    title: "Telegram",
     defaultIcons: "telegram.svg",
     url: "https://web.telegram.org/a/"
 });


### PR DESCRIPTION
Change the title of Telegram/redirect.js from "Telegram Keep" to "Telegram"

The icon hover currently lists this button as "Telegram Keep" without these changes.
<img width="425" alt="image" src="https://github.com/user-attachments/assets/993d123b-681f-477f-b2b4-067b40751e6d">
