### PR TITLE
Facebook messenger URL

### DIFF
--- a/Messenger/redirect.js
+++ b/Messenger/redirect.js
@@ -1,5 +1,5 @@
 browser.spacesToolbar.addButton('Messenger', {
     title: "Messenger",
     defaultIcons: "messenger.svg",
-    url: "https://www.messenger.com/"
+    url: "https://www.facebook.com/messages/"
 });


### PR DESCRIPTION
The "messenger.com" URL will soon become obsolete, updating redirect target to the working URL